### PR TITLE
[SCRUM-72] OAuth 공개 키 캐시

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
 
     // https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-openfeign
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.4'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0'
 
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/kotlin/com/ssak3/timeattack/TimeAttackApplication.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/TimeAttackApplication.kt
@@ -1,5 +1,6 @@
 package com.ssak3.timeattack
 
+import com.ssak3.timeattack.common.config.RedisProperties
 import com.ssak3.timeattack.member.auth.properties.KakaoProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -7,7 +8,7 @@ import org.springframework.boot.runApplication
 import org.springframework.cloud.openfeign.EnableFeignClients
 
 @SpringBootApplication
-@EnableConfigurationProperties(KakaoProperties::class)
+@EnableConfigurationProperties(KakaoProperties::class, RedisProperties::class)
 @EnableFeignClients
 class TimeAttackApplication
 

--- a/src/main/kotlin/com/ssak3/timeattack/common/config/RedisConfig.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/common/config/RedisConfig.kt
@@ -1,6 +1,6 @@
 package com.ssak3.timeattack.common.config
 
-import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -18,16 +18,14 @@ import java.time.Duration
 @Configuration
 @EnableCaching
 class RedisConfig(
-    @Value("\${spring.data.redis.host}") private val host: String,
-    @Value("\${spring.data.redis.port}") private val port: Int,
-    @Value("\${spring.data.redis.password}") private val password: String,
+    val redisProperties: RedisProperties,
 ) {
     @Bean
     fun redisConnectionFactory(): RedisConnectionFactory {
         val redisStandaloneConfiguration = RedisStandaloneConfiguration().apply {
-            hostName = host
-            port = this@RedisConfig.port
-            password = RedisPassword.of(this@RedisConfig.password)
+            hostName = redisProperties.host
+            port = redisProperties.port
+            password = RedisPassword.of(redisProperties.password)
         }
 
         return LettuceConnectionFactory(redisStandaloneConfiguration)
@@ -51,3 +49,10 @@ class RedisConfig(
             .build()
     }
 }
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+data class RedisProperties(
+    val host: String,
+    val port: Int,
+    val password: String,
+)

--- a/src/main/kotlin/com/ssak3/timeattack/common/config/RedisConfig.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/common/config/RedisConfig.kt
@@ -1,0 +1,53 @@
+package com.ssak3.timeattack.common.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.RedisPassword
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisConfig(
+    @Value("\${spring.data.redis.host}") private val host: String,
+    @Value("\${spring.data.redis.port}") private val port: Int,
+    @Value("\${spring.data.redis.password}") private val password: String,
+) {
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory {
+        val redisStandaloneConfiguration = RedisStandaloneConfiguration().apply {
+            hostName = host
+            port = this@RedisConfig.port
+            password = RedisPassword.of(this@RedisConfig.password)
+        }
+
+        return LettuceConnectionFactory(redisStandaloneConfiguration)
+    }
+
+    @Bean
+    fun redisCacheManager(redisConnectionFactory: RedisConnectionFactory): RedisCacheManager {
+        val configuration = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofDays(7))
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer())
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer()
+                )
+            )
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(configuration)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/ssak3/timeattack/common/constant/Cache.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/common/constant/Cache.kt
@@ -1,0 +1,7 @@
+package com.ssak3.timeattack.common.constant
+
+class Cache {
+    companion object {
+        const val OIDC_PUBLIC_KEYS = "oidcPublicKeys"
+    }
+}

--- a/src/main/kotlin/com/ssak3/timeattack/member/auth/client/KakaoFeignClient.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/member/auth/client/KakaoFeignClient.kt
@@ -1,6 +1,8 @@
 package com.ssak3.timeattack.member.auth.client
 
+import com.ssak3.timeattack.common.constant.Cache
 import com.ssak3.timeattack.member.auth.oidc.OIDCPublicKeyList
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.annotation.GetMapping
@@ -29,8 +31,9 @@ interface KakaoFeignClient {
 
     /**
      * 카카오 인증 서버가 ID 토큰 서명 시 사용한 공개키 목록을 조회
-     * TODO : 응답 값 Redis에 캐싱
+     * 조회 결과 Redis에 캐시
      */
     @GetMapping("/.well-known/jwks.json")
+    @Cacheable(value = [Cache.OIDC_PUBLIC_KEYS], key = "'kakao'")
     fun getPublicKeys(): OIDCPublicKeyList
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,15 @@ spring:
       hibernate:
         format_sql: true
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379
+      password: ${REDIS_PASSWORD}
+
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
   redirect-uri: ${KAKAO_REDIRECT_URI}
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+
+  profiles:
+    active: local
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${MYSQL_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
   data:
     redis:
       host: ${REDIS_HOST}
-      port: 6379
+      port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
 
 kakao:


### PR DESCRIPTION
## Jira Issue
SCRUM-72

## Proposed Changes
- provider에서 id token 파싱할 때 사용할 공개 키 조회 결과를 Redis 활용해 캐시

- [공식문서에 공개 키 캐시 권장하고 있음](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#oidc-find-public-key)

### 캐시 저장 형식
- String 데이터 구조 사용
- key : `oidcPublicKeys::kakao`
- value : `getPublicKeys()` 조회 결과 저장

## Code Review Point
